### PR TITLE
Host header is assigned to the proper attribute

### DIFF
--- a/src/reproxy/api/api.go
+++ b/src/reproxy/api/api.go
@@ -151,6 +151,9 @@ func type_proxy(c *golax.Context, e *model.Entry) {
 
 		for _, h := range type_proxy.ProxyHeaders {
 			r.Header.Add(h.Key, h.Value)
+			if "Host" == h.Key {
+				r.Host = h.Value
+			}
 		}
 	}
 


### PR DESCRIPTION
Golang uses attribute `Host` instead of `headers["Host"]`, this fix workaround that issue